### PR TITLE
liquidFillGauge.js port for D3 version 4.0 API

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <svg id="fillgauge4" width="19%" height="200"></svg>
 <svg id="fillgauge5" width="19%" height="200"></svg>
 <svg id="fillgauge6" width="19%" height="200"></svg>
-<script src="http://d3js.org/d3.v3.min.js" type="text/javascript"></script>
+<script src="http://d3js.org/d3.v4.min.js" type="text/javascript"></script>
 <script src="liquidFillGauge.js" type="text/javascript"></script>
 <script type="text/javascript">
     d3.select("#fillgauge1").call(d3.liquidfillgauge, 55);

--- a/liquidFillGauge.js
+++ b/liquidFillGauge.js
@@ -57,7 +57,7 @@
     d3.liquidfillgauge = function(g, value, settings) {
         // Handle configuration
         var config = d3.map(defaultConfig);
-        d3.map(settings).forEach(function(key, val) {
+        d3.map(settings).each(function(val, key) {
             config.set(key, val);
         });
 
@@ -73,11 +73,11 @@
 
             var waveHeightScale;
             if (config.get("waveHeightScaling")) {
-              waveHeightScale = d3.scale.linear()
+              waveHeightScale = d3.scaleLinear()
                   .range([0, config.get("waveHeight"), 0])
                   .domain([0, 50, 100]);
             } else {
-                waveHeightScale = d3.scale.linear()
+                waveHeightScale = d3.scaleLinear()
                   .range([config.get("waveHeight"), config.get("waveHeight")])
                   .domain([0, 100]);
             }
@@ -121,30 +121,30 @@
             }
 
             // Scales for drawing the outer circle.
-            var gaugeCircleX = d3.scale.linear().range([0, 2 * Math.PI]).domain([0, 1]);
-            var gaugeCircleY = d3.scale.linear().range([0, radius]).domain([0, radius]);
+            var gaugeCircleX = d3.scaleLinear().range([0, 2 * Math.PI]).domain([0, 1]);
+            var gaugeCircleY = d3.scaleLinear().range([0, radius]).domain([0, radius]);
 
             // Scales for controlling the size of the clipping path.
-            var waveScaleX = d3.scale.linear().range([0, waveClipWidth]).domain([0, 1]);
-            var waveScaleY = d3.scale.linear().range([0, waveHeight]).domain([0, 1]);
+            var waveScaleX = d3.scaleLinear().range([0, waveClipWidth]).domain([0, 1]);
+            var waveScaleY = d3.scaleLinear().range([0, waveHeight]).domain([0, 1]);
 
             // Scales for controlling the position of the clipping path.
-            var waveRiseScale = d3.scale.linear()
+            var waveRiseScale = d3.scaleLinear()
             // The clipping area size is the height of the fill circle + the wave height, so we position the clip wave
             // such that the it will won't overlap the fill circle at all when at 0%, and will totally cover the fill
             // circle at 100%.
               .range([(fillCircleMargin + fillCircleRadius * 2 + waveHeight), (fillCircleMargin - waveHeight)])
               .domain([0, 1]);
-            var waveAnimateScale = d3.scale.linear()
+            var waveAnimateScale = d3.scaleLinear()
               .range([0, waveClipWidth - fillCircleRadius * 2]) // Push the clip area one full wave then snap back.
               .domain([0, 1]);
 
             // Scale for controlling the position of the text within the gauge.
-            var textRiseScaleY = d3.scale.linear()
+            var textRiseScaleY = d3.scaleLinear()
               .range([fillCircleMargin + fillCircleRadius * 2, (fillCircleMargin + textPixels * 0.7)])
               .domain([0, 1]);
 
-            // Center the gauge within the parent SVG.
+            // Center the gauge within the parent
             var gaugeGroup = gauge.append("g")
               .attr('transform', 'translate(' + locationX + ',' + locationY + ')');
 
@@ -157,7 +157,7 @@
             }
 
             // Draw the outer circle.
-            var gaugeCircleArc = d3.svg.arc()
+            var gaugeCircleArc = d3.arc()
               .startAngle(gaugeCircleX(0))
               .endAngle(gaugeCircleX(1))
               .outerRadius(gaugeCircleY(radius))
@@ -176,7 +176,7 @@
               .attr('transform', 'translate(' + radius + ',' + textRiseScaleY(config.get("textVertPosition")) + ')');
 
             // The clipping wave area.
-            var clipArea = d3.svg.area()
+            var clipArea = d3.area()
               .x(function(d) {
                   return waveScaleX(d.x);
               })
@@ -241,9 +241,9 @@
                 var animateWave = function() {
                     wave.transition()
                       .duration(config.get("waveAnimateTime"))
-                      .ease("linear")
+                      .ease(d3.easeLinear)
                       .attr('transform', 'translate(' + waveAnimateScale(1) + ',0)')
-                      .each("end", function() {
+                      .on("end", function() {
                           wave.attr('transform', 'translate(' + waveAnimateScale(0) + ',0)');
                           animateWave();
                       });
@@ -255,9 +255,10 @@
                 // Update texts and animate
                 if (animateText) {
                     var textTween = function() {
+                        var that = d3.select(this);
                         var i = d3.interpolate(from, to);
                         return function(t) {
-                            this.textContent = textRounder(i(t)) + percentText;
+                            that.text(textRounder(i(t)) + percentText);
                         };
                     };
                     text1.transition()


### PR DESCRIPTION
This is same source code but ported to D3 version 4.0 API as version 3.0 is mostly deprecated and I don't feel comfortable having both version running in same website.
  * Updated index.html for using version 4.0
  * Updated to new version 4.0 API (https://github.com/d3/d3/blob/master/CHANGES.md)

